### PR TITLE
fix memory leak

### DIFF
--- a/tdlib.go
+++ b/tdlib.go
@@ -47,8 +47,9 @@ type Client struct {
 	Config       Config
 	rawUpdates   chan UpdateMsg
 	receivers    []EventReceiver
-	waiters      sync.Map
+	waiters      map[string]chan UpdateMsg
 	receiverLock *sync.Mutex
+	rwMutex      *sync.RWMutex
 }
 
 // Config holds tdlibParameters
@@ -81,7 +82,9 @@ func NewClient(config Config) *Client {
 	client := Client{Client: C.td_json_client_create()}
 	client.receivers = make([]EventReceiver, 0, 1)
 	client.receiverLock = &sync.Mutex{}
+	client.rwMutex = &sync.RWMutex{}
 	client.Config = config
+	client.waiters = make(map[string]chan UpdateMsg)
 
 	go func() {
 		for {
@@ -93,13 +96,17 @@ func NewClient(config Config) *Client {
 			// does new update has @extra field?
 			if extra, hasExtra := updateData["@extra"].(string); hasExtra {
 
+				client.rwMutex.RLock()
+				waiter, found := client.waiters[extra]
+				client.rwMutex.RUnlock()
+
 				// trying to load update with this salt
-				if waiter, found := client.waiters.Load(extra); found {
+				if found {
 					// found? send it to waiter channel
-					waiter.(chan UpdateMsg) <- UpdateMsg{Data: updateData, Raw: updateBytes}
+					waiter <- UpdateMsg{Data: updateData, Raw: updateBytes}
 
 					// trying to prevent memory leak
-					close(waiter.(chan UpdateMsg))
+					close(waiter)
 				}
 			} else {
 				// does new updates has @type field?
@@ -266,7 +273,10 @@ func (client *Client) SendAndCatch(jsonQuery interface{}) (UpdateMsg, error) {
 
 	// create waiter chan and save it in Waiters
 	waiter := make(chan UpdateMsg, 1)
-	client.waiters.Store(randomString, waiter)
+
+	client.rwMutex.Lock()
+	client.waiters[randomString] = waiter
+	client.rwMutex.Unlock()
 
 	// send it through already implemented method
 	client.Send(update)
@@ -274,10 +284,17 @@ func (client *Client) SendAndCatch(jsonQuery interface{}) (UpdateMsg, error) {
 	select {
 	// wait response from main loop in NewClient()
 	case response := <-waiter:
+		client.rwMutex.Lock()
+		delete(client.waiters, randomString)
+		client.rwMutex.Unlock()
+
 		return response, nil
 		// or timeout
 	case <-time.After(10 * time.Second):
-		client.waiters.Delete(randomString)
+		client.rwMutex.Lock()
+		delete(client.waiters, randomString)
+		client.rwMutex.Unlock()
+
 		return UpdateMsg{}, errors.New("timeout")
 	}
 }


### PR DESCRIPTION
A memory leak was detected during load testing and application profiling. All screenshots were taken at approximately the same time (about 20 minutes from the application start).

![image](https://user-images.githubusercontent.com/55066322/110388743-9b009380-8074-11eb-9a08-80ae645eaed6.png)
This screenshot shows the memory allocation for the SendAndCatch method, where flat = 557 MB and cum = 773 MB.
A memory leak occurs due to the removal of channel _waiter_ from the _waiters_ map only if the time for processing the request expires (timeout error). Thus, any successfully completed request will not cause the channel to be removed from the map. This leads to a noticeable increase in the size of the map up to killing the process due to lack of memory.

![image](https://user-images.githubusercontent.com/55066322/110477732-9380cf00-80f4-11eb-838b-d894126d044f.png)
After fixing the indicated problem, cum fluctuates from 3 to 10 MB.

Also, in my opinion, using sync.Map in this library is inefficient and unnecessary.
The [documentation](https://golang.org/src/sync/map.go) says: "The Map type is optimized for two common use cases: (1) when the entry for a given key is only ever written once but read many times, as in caches that only grow, or (2) when multiple goroutines read, write, and overwrite entries for disjoint sets of keys. In these two cases, use of a Map may significantly reduce lock contention compared to a Go map paired with a separate Mutex or RWMutex. "
As far as I understand, both of the above cases are not used in the library.

> Signed-off-by: Julia Bezrukova <julika7391@gmail.com>